### PR TITLE
UHM-4567 - Order x-ray page on tablet

### DIFF
--- a/omod/src/main/compass/sass/radiologyOrder.scss
+++ b/omod/src/main/compass/sass/radiologyOrder.scss
@@ -1,6 +1,4 @@
 .left-column, .right-column {
-  display: inline-block;
-  width: 45%;
   padding-bottom: 20px;
   vertical-align: top;
 }
@@ -30,6 +28,14 @@
   text-align: center;
 }
 
+#creatinine-level-field-input {
+  display: inline;
+  min-width: fit-content;
+}
+
+.question {
+  padding-top: 20px;
+}
 
 #study-search {
   width: 330px;
@@ -64,7 +70,7 @@
   }
 }
 
-.row {
+.detail-row {
   display: table-row;
 
   input, span, .select, input[type="checkbox"] {
@@ -78,45 +84,25 @@
   padding-right: 50px;
 
   #who-where-when-edit {
-    margin-bottom: 6px;
-    border-bottom: 1px solid #ccc;
-
-    #requestedOn-display {
-      width: 150px;
-      min-width: 0;
-    }
-
-    #requestedBy-field, #requestedFrom-field {
-      width: 200px;
-      min-width: 0;
-    }
-
-    label {
-      margin-top: 0;
-    }
+    padding-bottom: 20px;
   }
 
   #who-where-when-view {
-    width: 600px;
     margin: 0;
-    margin-bottom: 30px;
-
-    td {
-      padding-left: 5px;
-
-      label {
-        margin-top: 0;
-      }
-    }
+    padding-bottom: 20px;
   }
 
-  #who-where-when-edit, #who-where-when-view {
-    p, td {
-      width: 210px;
-    }
-    p {
-      display: inline-block;
-    }
+  #requestedOn-display {
+    width: 150px;
+    min-width: 0;
   }
 
+  #requestedBy-field, #requestedFrom-field {
+    width: 200px;
+    min-width: 0;
+  }
+
+  label {
+    margin-top: 0;
+  }
 }

--- a/omod/src/main/webapp/pages/orderRadiology.gsp
+++ b/omod/src/main/webapp/pages/orderRadiology.gsp
@@ -1,5 +1,5 @@
 <%
-    ui.decorateWith("appui", "standardEmrPage", [includeBootstrap: false])
+    ui.decorateWith("appui", "standardEmrPage", [includeBootstrap: true])
     ui.includeJavascript("uicommons", "knockout-2.2.1.js")
     ui.includeJavascript("radiologyapp", "radiologyOrder.js")
 
@@ -61,144 +61,157 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
         <input type="hidden" name="modality" value="${ modality }"/>
         <input type="hidden" name="visit" value="${ visit.id }" />
 
-        <table id="who-where-when-view"<% if (areProviderLocationAndDateEditable) { %>  class="hidden" <% } %> ><tr>
-            <td>
-                <label>${ ui.message("radiologyapp.order.requestedBy") }</label>
+        <div id="who-where-when-view" class="row <% if (areProviderLocationAndDateEditable) { %> hidden <% } %>">
+            <div class="col-12 col-lg-4">
+                <h5>${ ui.message("radiologyapp.order.requestedBy") }</h5>
                 <span>${ ui.format(emrContext.currentProvider) }</span>
-            </td>
-            <td>
-                <label>${ ui.message("radiologyapp.order.requestedFrom") }</label>
+            </div>
+            <div class="col-12 col-lg-4">
+                <h5>${ ui.message("radiologyapp.order.requestedFrom") }</h5>
                 <span>${ ui.format(sessionContext.sessionLocation) }</span>
-            </td>
-            <td>
-                <label>${ ui.message("radiologyapp.order.requestedOn") }</label>
+            </div>
+            <div class="col-12 col-lg-4">
+                <h5>${ ui.message("radiologyapp.order.requestedOn") }</h5>
                 <span>${ ui.format(defaultOrderDate) }</span>
-            </td>
-        </tr></table>
-
-        <div id="who-where-when-edit"<% if (!areProviderLocationAndDateEditable) { %>  class="hidden" <% } %> >
-            ${ ui.includeFragment("uicommons", "field/dropDown", [
-                    id: "requestedBy",
-                    label: "radiologyapp.order.requestedBy",
-                    formFieldName: "requestedBy",
-                    options: providers,
-                    classes: ['required'],
-                    initialValue: areProviderLocationAndDateEditable ? null : emrContext.currentProvider.providerId
-            ])}
-
-            ${ ui.includeFragment("emr", "field/location", [
-                    id: "requestedFrom",
-                    label: "radiologyapp.order.requestedFrom",
-                    formFieldName: "requestedFrom",
-                    classes: ['required'],
-                    withTag: "Login Location",
-                    initialValue: areProviderLocationAndDateEditable ? null : sessionContext.sessionLocationId
-            ])}
-
-            ${ ui.includeFragment("uicommons", "field/datetimepicker", [
-                    id: "requestedOn",
-                    label: "radiologyapp.order.requestedOn",
-                    formFieldName: "requestedOn",
-                    useTime: false,
-                    defaultDate: defaultOrderDate,
-                    startDate:minOrderDate,
-                    endDate: maxOrderDate,
-                    classes: ['required']
-            ])}
+            </div>
         </div>
 
-        <div class="left-column">
-            <label for="study-search">${ ui.message("radiologyapp.order.studySearchInstructions") }</label>
-            <input id="study-search" type="text"
-                   autofocus="autofocus"
-                   data-bind="autocomplete:searchTerm, search:convertedStudies, select:selectStudy, clearValue:function() { return true; }"
-                   placeholder="${ ui.message("radiologyapp.order." + modality + ".studySearchPlaceholder") }"/>
-
-            <label for="clinical-history-field">
-                <label>${ ui.message("radiologyapp.order.indication") } (${ ui.message("emr.formValidation.messages.requiredField.label") })</label>
-            </label>
-
-            <div id="clinical-history-field">
-                <textarea class="field-value" rows="5" cols="35" name="clinicalHistory" data-bind="value: clinicalHistory"></textarea>
-                <span class="field-error"  style="display: none" ></span>
+        <div id="who-where-when-edit" class="row <% if (!areProviderLocationAndDateEditable) { %> hidden <% } %>">
+            <div class="col-12 col-lg-4">
+                ${ ui.includeFragment("uicommons", "field/dropDown", [
+                        id: "requestedBy",
+                        label: "radiologyapp.order.requestedBy",
+                        formFieldName: "requestedBy",
+                        options: providers,
+                        classes: ['required'],
+                        initialValue: areProviderLocationAndDateEditable ? null : emrContext.currentProvider.providerId
+                ])}
             </div>
-
-            <!-- fields to collection creatinine level, only used in contrast exams -->
-            <span data-bind="visible: selectedStudiesIncludeContrastStudy()">
-                <label for="creatinine-level-field">
-                    <label>${ ui.message("radiologyapp.order.creatinineLevel") }(${ ui.message("emr.formValidation.messages.requiredField.label") })</label>
-                </label>
-
-                <div id="creatinine-level-field">
-                    <input id="creatinine-level-field-input" name="creatinineLevel" class="field-value inline" style="width:50px;" size="10" data-bind="value: creatinineLevel"/>
-                    <span class="inline">${ ui.message("radiologyapp.order.creatinineUnits") }</span>
-                </div>
-
+            <div class="col-12 col-lg-4">
+                ${ ui.includeFragment("emr", "field/location", [
+                        id: "requestedFrom",
+                        label: "radiologyapp.order.requestedFrom",
+                        formFieldName: "requestedFrom",
+                        classes: ['required'],
+                        withTag: "Login Location",
+                        initialValue: areProviderLocationAndDateEditable ? null : sessionContext.sessionLocationId
+                ])}
+            </div>
+            <div class="col-12 col-lg-4">
                 ${ ui.includeFragment("uicommons", "field/datetimepicker", [
-                        id: "creatinineTestDate",
-                        label: "radiologyapp.order.creatinineTestDate",
-                        formFieldName: "creatinineTestDate",
+                        id: "requestedOn",
+                        label: "radiologyapp.order.requestedOn",
+                        formFieldName: "requestedOn",
                         useTime: false,
-                        defaultDate: defaultCreatinineTestDate,
-                        startDate:minCreatinineTestDate,
-                        endDate: maxCreatinineTestDate,
+                        defaultDate: defaultOrderDate,
+                        startDate:minOrderDate,
+                        endDate: maxOrderDate,
                         classes: ['required']
                 ])}
-            </span>
-
+            </div>
         </div>
 
-        <div class="right-column">
-            <div class="row">
-                ${ ui.includeFragment("uicommons", "field/radioButtons", [
-                        label: ui.message("radiologyapp.order.timing"),
-                        formFieldName: "urgency",
-                        options: [
-                                [ value: "ROUTINE", label: ui.message("radiologyapp.order.timing.routine"), checked: true ],
-                                [ value: "STAT", label: ui.message("radiologyapp.order.timing.urgent") ]
-                        ]
-                ]) }
-            </div>
-
-            <% if (modality.equalsIgnoreCase(xrayModalityCode)) { %>
-                <!-- for now, only x-ray (CR) orders can be portable -->
-                <div class="row">
-                    <p><label>${ ui.message("radiologyapp.order.portableQuestion") }</label></p>
-                    <p>
-                        <input type="checkbox" class="field-value" value="portable" data-bind="checked: portable"/>
-                        <span>${ ui.message("radiologyapp.yes") }</span>
-                        <select name="examLocation" data-bind="enable:portable, options:locations, optionsText:'name', optionsValue:'id', optionsCaption:'${ ui.escapeJs(ui.message("radiologyapp.order.examLocationQuestion")) }', value:portableLocation">
-                        </select>
-                    </p>
+        <div class="row">
+            <div class="left-column col-12 col-lg-6">
+                <div class="question">
+                    <label for="study-search">${ ui.message("radiologyapp.order.studySearchInstructions") }</label>
+                    <input id="study-search" type="text"
+                           autofocus="autofocus"
+                           data-bind="autocomplete:searchTerm, search:convertedStudies, select:selectStudy, clearValue:function() { return true; }"
+                           placeholder="${ ui.message("radiologyapp.order." + modality + ".studySearchPlaceholder") }"/>
                 </div>
-            <% } %>
+                <div class="question">
+                    <label for="clinical-history-field">
+                        <label>${ ui.message("radiologyapp.order.indication") } (${ ui.message("emr.formValidation.messages.requiredField.label") })</label>
+                    </label>
+                    <div id="clinical-history-field">
+                        <textarea class="field-value" rows="5" cols="35" name="clinicalHistory" data-bind="value: clinicalHistory"></textarea>
+                        <span class="field-error"  style="display: none" ></span>
+                    </div>
+                </div>
 
-
-             <div data-bind="visible: selectedStudies().length == 0">
-                <span style="color: blue;">${ ui.message("radiologyapp.order.noStudiesSelected") }</span>
+                <!-- fields to collection creatinine level, only used in contrast exams -->
+                <span data-bind="visible: selectedStudiesIncludeContrastStudy()">
+                    <div class="question">
+                        <label for="creatinine-level-field">
+                            <label>${ ui.message("radiologyapp.order.creatinineLevel") } (${ ui.message("emr.formValidation.messages.requiredField.label") })</label>
+                        </label>
+                        <div id="creatinine-level-field">
+                            <input id="creatinine-level-field-input" name="creatinineLevel" class="field-value inline" style="width:50px;" size="10" data-bind="value: creatinineLevel"/>
+                            <span class="inline">${ ui.message("radiologyapp.order.creatinineUnits") }</span>
+                        </div>
+                    </div>
+                    <div class="question">
+                        ${ ui.includeFragment("uicommons", "field/datetimepicker", [
+                                id: "creatinineTestDate",
+                                label: "radiologyapp.order.creatinineTestDate",
+                                formFieldName: "creatinineTestDate",
+                                useTime: false,
+                                defaultDate: defaultCreatinineTestDate,
+                                startDate:minCreatinineTestDate,
+                                endDate: maxCreatinineTestDate,
+                                classes: ['required']
+                        ])}
+                    </div>
+                </span>
             </div>
-            <div data-bind="visible: selectedStudies().length > 0">
-                <label>${ ui.message("radiologyapp.order.selectedStudies") }</label>
-                <ul id="selected-studies" data-bind="foreach: selectedStudies">
-                    <li>
-                        <input type="hidden" data-bind="value: id" name="studies" />
-                        <span data-bind="text: name"></span>
-                        <span data-bind="click: \$root.unselectStudy">X</span>
-                    </li>
-                </ul>
+            <div class="right-column col-12 col-lg-6">
+                <div class="question">
+                    <div class="detail-row">
+                        ${ ui.includeFragment("uicommons", "field/radioButtons", [
+                                label: ui.message("radiologyapp.order.timing"),
+                                formFieldName: "urgency",
+                                options: [
+                                        [ value: "ROUTINE", label: ui.message("radiologyapp.order.timing.routine"), checked: true ],
+                                        [ value: "STAT", label: ui.message("radiologyapp.order.timing.urgent") ]
+                                ]
+                        ]) }
+                    </div>
+                </div>
+
+                <% if (modality.equalsIgnoreCase(xrayModalityCode)) { %>
+                    <!-- for now, only x-ray (CR) orders can be portable -->
+                    <div class="question">
+                        <div class="detail-row">
+                            <p><label>${ ui.message("radiologyapp.order.portableQuestion") }</label></p>
+                            <p>
+                                <input type="checkbox" class="field-value" value="portable" data-bind="checked: portable"/>
+                                <span>${ ui.message("radiologyapp.yes") }</span>
+                                <select name="examLocation" data-bind="enable:portable, options:locations, optionsText:'name', optionsValue:'id', optionsCaption:'${ ui.escapeJs(ui.message("radiologyapp.order.examLocationQuestion")) }', value:portableLocation">
+                                </select>
+                            </p>
+                        </div>
+                    </div>
+                <% } %>
+
+                <div data-bind="visible: selectedStudies().length == 0">
+                    <span style="color: blue;">${ ui.message("radiologyapp.order.noStudiesSelected") }</span>
+                </div>
+                <div data-bind="visible: selectedStudies().length > 0">
+                    <label>${ ui.message("radiologyapp.order.selectedStudies") }</label>
+                    <ul id="selected-studies" data-bind="foreach: selectedStudies">
+                        <li>
+                            <input type="hidden" data-bind="value: id" name="studies" />
+                            <span data-bind="text: name"></span>
+                            <span data-bind="click: \$root.unselectStudy">X</span>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
 
-        <div id="bottom">
-            <!-- note that setting type="reset" is necessary here to prevent the cancel button from actually submitting the form! -->
-            <button type="reset" id="cancel" class="cancel" onclick="location.href = '${returnUrl ?: ui.pageLink("coreapps", "patientdashboard/patientDashboard", [patientId: patient.id])}'">
-                ${ ui.message("radiologyapp.cancel") }
-            </button>
-            <button type="submit" class="confirm" id="next" data-bind="css: { disabled: !isValid() }, enable: isValid()">
-                ${ ui.message("radiologyapp.save") }
-                <i class="icon-spinner icon-spin icon-2x" style="display: none; margin-left: 10px;"></i>
-            </button>
-            <br/><br/><br/><br/><br/><br/><br/><br/>
+        <div class="row">
+            <div class="col-12" id="bottom">
+                <!-- note that setting type="reset" is necessary here to prevent the cancel button from actually submitting the form! -->
+                <button type="reset" id="cancel" class="cancel" onclick="location.href = '${returnUrl ?: ui.pageLink("coreapps", "patientdashboard/patientDashboard", [patientId: patient.id])}'">
+                    ${ ui.message("radiologyapp.cancel") }
+                </button>
+                <button type="submit" class="confirm" id="next" data-bind="css: { disabled: !isValid() }, enable: isValid()">
+                    ${ ui.message("radiologyapp.save") }
+                    <i class="icon-spinner icon-spin icon-2x" style="display: none; margin-left: 10px;"></i>
+                </button>
+                <br/><br/><br/><br/><br/><br/><br/><br/>
+            </div>
         </div>
     </form>
 </div>


### PR DESCRIPTION
This PR improves the layout and styling of the order radiology page, and incorporates bootstrap styling to be consistent with the rest of the reference application and to enable improved responsiveness when viewed on a mobile device.  Before and after screenshots follow:

**Before and after of large screen view (note some improvements to layout here)**

Before large screen:
![order-radiology-before](https://user-images.githubusercontent.com/356297/82956889-cc91ed80-9f7f-11ea-85c9-3834120533c8.png)

After large screen:
![order-radiology-after](https://user-images.githubusercontent.com/356297/82956892-d0257480-9f7f-11ea-91ca-19ff7841d118.png)

After large screen, creatinine question included:
![order-radiology-after-with-creatinine](https://user-images.githubusercontent.com/356297/82957000-0cf16b80-9f80-11ea-88ca-cce1d7a57cde.png)

**Before and after of mobile screen view**

Before mobile:
![order-radiology-before-mobile](https://user-images.githubusercontent.com/356297/82956923-df0c2700-9f7f-11ea-9d52-65e434d941aa.png)

After mobile:
![order-radiology-after-mobile-1](https://user-images.githubusercontent.com/356297/82956931-e3384480-9f7f-11ea-943f-5d75e390de19.png)

After mobile, scrolled down, if creatinine were enabled:
![order-radiology-after-2-with-creatinine](https://user-images.githubusercontent.com/356297/82957006-0fec5c00-9f80-11ea-8ede-0c3668a2b38d.png)

After mobile, if provider/location/date are not editable:
![order-radiology-after-mobile-non-editable-fields](https://user-images.githubusercontent.com/356297/82957012-137fe300-9f80-11ea-92ef-fb335bf1ebe6.png)

@mogoodrich FYI
